### PR TITLE
fix: removed unnecessary function killing performance

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -22,7 +22,6 @@ if Config.UseCarHud then
         local speedBuffer, velBuffer  = {0.0,0.0}, {}
 
         while true do
-            WaitPlayer()
             if IsPedInAnyVehicle(Player, false) then
                 DisplayRadar(true)
                 sleep = 1
@@ -123,7 +122,6 @@ end
 
 CreateThread(function()
     while true do
-        WaitPlayer()
         local StreetHash = GetStreetNameAtCoord(PlayerPosition.x, PlayerPosition.y, PlayerPosition.z)
         local Street = GetStreetNameFromHashKey(StreetHash)
 
@@ -139,7 +137,6 @@ end)
 CreateThread(function()
     local hunger, thirst
     while true do
-        WaitPlayer()
         local health = GetEntityHealth(Player)
         local val = health - 100
         local armour = GetPedArmour(Player)
@@ -208,27 +205,3 @@ function IsCar(veh)
     local vc = GetVehicleClass(veh)
     return (vc >= 0 and vc <= 7) or (vc >= 9 and vc <= 12) or (vc >= 17 and vc <= 20)
 end 
-
-function WaitPlayer()
-    if Config.Framework == "esx" then
-        while ESX == nil do
-            Citizen.Wait(0)
-        end
-        while ESX.GetPlayerData()  == nil do
-            Citizen.Wait(0)
-        end
-        while ESX.GetPlayerData().job == nil do
-            Citizen.Wait(0)
-        end       
-    else
-        while QBCore == nil do
-            Citizen.Wait(0)
-        end
-        while QBCore.Functions.GetPlayerData() == nil do
-            Citizen.Wait(0)
-        end
-        while QBCore.Functions.GetPlayerData().metadata == nil do
-            Citizen.Wait(0)
-        end
-    end
-end


### PR DESCRIPTION
We don't need this if `exports['es_extended']:getSharedObject()` is used, most likely same for qb-core.